### PR TITLE
Normalized data in Temporal page (closed #36)

### DIFF
--- a/src/frontend/features/temporal/utils/barchart.tsx
+++ b/src/frontend/features/temporal/utils/barchart.tsx
@@ -13,5 +13,11 @@ export function formatYAxisTick(unit: string, value: number) {
         return Math.round(value).toLocaleString()
     }
 
+    if (unit === "rides/day") {
+        if (value >= 1e6) return (value / 1e6).toFixed(1) + "M"
+        if (value >= 1e3) return (value / 1e3).toFixed(1) + "k"
+        return Number(value).toFixed(1)
+    }
+
     return Number(value).toFixed(1)
 }

--- a/src/frontend/features/temporal/utils/metric_formatter.jsx
+++ b/src/frontend/features/temporal/utils/metric_formatter.jsx
@@ -1,18 +1,35 @@
 // Utility functions and configurations for formatting and retrieving metrics
 export const METRIC_FORMATTERS = {
-    total_rides: value => Math.round(value).toLocaleString(),
+    total_rides: value => value.toFixed(1),
     total_duration_minutes: value => value.toFixed(1) + " min",
     average_duration_minutes: value => value.toFixed(1) + " min",
     total_distance: value => value.toFixed(1) + " km",
     average_distance: value => value.toFixed(1) + " km",
     average_speed_kmh: value => value.toFixed(1) + " km/h",
 }
+
+function getRidesPerDay(row) {
+    const totalRides = Number(row?.total_rides ?? 0)
+    const hoursCount = Number(row?.hours_count ?? 0)
+
+    if (!Number.isFinite(totalRides) || !Number.isFinite(hoursCount) || hoursCount <= 0) {
+        return 0
+    }
+
+    // day_of_week buckets include all 24 hours for each matching weekday.
+    // hour and day+hour buckets contain one hour slot per day occurrence.
+    const daysCount = row?.day_of_week != null && row?.hour == null
+        ? hoursCount / 24
+        : hoursCount
+
+    return daysCount > 0 ? totalRides / daysCount : 0
+}
 // Configuration object that defines the available metrics
 export const METRICS = {
     total_rides: {
-        label: "Total Rides",
-        unit: "rides",
-        get: row => row.total_rides,
+        label: "Rides per Day",
+        unit: "rides/day",
+        get: getRidesPerDay,
         format: METRIC_FORMATTERS.total_rides,
     },
     average_duration_minutes: {


### PR DESCRIPTION
Replaced "Total Rides" metric with "Rides per Day", as specified in #36. I'm open to suggestions or edit requests