### PR TITLE
Increase timeout for dataset download and seeding

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -172,7 +172,7 @@ jobs:
           done
 
       - name: Download and seed default dataset
-        timeout-minutes: 45
+        timeout-minutes: 120
         run: |
           docker run --rm \
             --network container:pg \


### PR DESCRIPTION
Increased timeout for downloading and seeding dataset from 45 to 120 minutes.