### PR TITLE
Enhance data partitioning; split config files

### DIFF
--- a/postgres/schemas/002_station_activity_hourly.sql
+++ b/postgres/schemas/002_station_activity_hourly.sql
@@ -1,6 +1,6 @@
--- 002_station_activity_hourly.sql
--- Define the schema for the station_activity_hourly table, which aggregates ride data by YEAR,
--- MONTH, DAY_OF_WEEK, HOUR, STATION_ID, USER_TYPE, and BIKE_TYPE.
+-- Full granularity: year, month, day_of_week, hour, station, user_type, bike_type.
+-- Used for group_by=DAY_OF_WEEK_AND_HOUR and as fallback when a day_of_week filter
+-- is combined with group_by=HOUR.
 CREATE TABLE IF NOT EXISTS station_activity_hourly (
     year            SMALLINT     NOT NULL,
     month           SMALLINT     NOT NULL,
@@ -12,4 +12,45 @@ CREATE TABLE IF NOT EXISTS station_activity_hourly (
     outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
     incoming_rides  INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, day_of_week, hour, station_id, user_type, bike_type)
+);
+
+-- Pre-aggregated variants: each collapses one or more dimensions to speed up
+-- common query shapes without scanning the full hourly table.
+
+-- Collapses day_of_week and hour — used for group_by=NONE
+CREATE TABLE IF NOT EXISTS station_activity_by_month (
+    year            SMALLINT     NOT NULL,
+    month           SMALLINT     NOT NULL,
+    station_id      VARCHAR(20)  NOT NULL,
+    user_type       VARCHAR(10)  NOT NULL,
+    bike_type       VARCHAR(20)  NOT NULL,
+    outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
+    incoming_rides  INTEGER      NOT NULL DEFAULT 0,
+    PRIMARY KEY (year, month, station_id, user_type, bike_type)
+);
+
+-- Collapses day_of_week — used for group_by=HOUR
+CREATE TABLE IF NOT EXISTS station_activity_by_hour (
+    year            SMALLINT     NOT NULL,
+    month           SMALLINT     NOT NULL,
+    hour            SMALLINT     NOT NULL,
+    station_id      VARCHAR(20)  NOT NULL,
+    user_type       VARCHAR(10)  NOT NULL,
+    bike_type       VARCHAR(20)  NOT NULL,
+    outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
+    incoming_rides  INTEGER      NOT NULL DEFAULT 0,
+    PRIMARY KEY (year, month, hour, station_id, user_type, bike_type)
+);
+
+-- Collapses hour — used for group_by=DAY_OF_WEEK and group_by=NONE with a dow filter
+CREATE TABLE IF NOT EXISTS station_activity_by_dow (
+    year            SMALLINT     NOT NULL,
+    month           SMALLINT     NOT NULL,
+    day_of_week     SMALLINT     NOT NULL,
+    station_id      VARCHAR(20)  NOT NULL,
+    user_type       VARCHAR(10)  NOT NULL,
+    bike_type       VARCHAR(20)  NOT NULL,
+    outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
+    incoming_rides  INTEGER      NOT NULL DEFAULT 0,
+    PRIMARY KEY (year, month, day_of_week, station_id, user_type, bike_type)
 );

--- a/postgres/schemas/008_indexes.sql
+++ b/postgres/schemas/008_indexes.sql
@@ -1,5 +1,5 @@
 -- stats_hourly
-CREATE INDEX IF NOT EXISTS idx_sh_date 
+CREATE INDEX IF NOT EXISTS idx_sh_date
 ON stats_hourly (date);
 
 -- station_activity_hourly
@@ -14,6 +14,18 @@ ON station_activity_hourly (station_id);
 
 CREATE INDEX IF NOT EXISTS idx_sah_station_year_month
 ON station_activity_hourly (station_id, year, month);
+
+-- station_activity_by_month
+CREATE INDEX IF NOT EXISTS idx_sabm_year_month
+ON station_activity_by_month (year, month);
+
+-- station_activity_by_hour
+CREATE INDEX IF NOT EXISTS idx_sabh_year_month
+ON station_activity_by_hour (year, month);
+
+-- station_activity_by_dow
+CREATE INDEX IF NOT EXISTS idx_sabdow_year_month
+ON station_activity_by_dow (year, month);
 
 -- flow_activity_monthly
 CREATE INDEX IF NOT EXISTS idx_fam_year_month

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from datetime import datetime, timedelta
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Data directories
+DATA_DIR               = PROJECT_ROOT / "data"
+RIDES_DATA_DIR         = DATA_DIR / "rides"
+WEATHER_DATA_DIR       = DATA_DIR / "weather"
+STATION_DATA_DIR       = DATA_DIR / "stations"
+STATION_DISTANCES_PATH = STATION_DATA_DIR / "station_pair_distances.parquet"
+BIKE_ROUTES_DATA_DIR   = DATA_DIR / "bike_routes"
+BIKE_ROUTES_PATH       = BIKE_ROUTES_DATA_DIR / "bike_routes.parquet"
+DAILY_STATS_DATA_DIR   = DATA_DIR / "daily_stats"
+DAILY_STATS_PATH       = DAILY_STATS_DATA_DIR / "daily_stats.parquet"
+
+# Download URLs
+BASE_URL_RIDE_DATA = "https://s3.amazonaws.com/tripdata/"
+WEATHER_API_URL    = "https://archive-api.open-meteo.com/v1/archive"
+BIKE_ROUTES_URL    = "https://data.cityofnewyork.us/api/views/mzxg-pwib/rows.csv?accessType=DOWNLOAD"
+
+# Default date range for data ingestion
+DEFAULT_START_DATE = "202501"
+_one_month_ago     = datetime.now() - timedelta(days=30)
+DEFAULT_END_DATE   = _one_month_ago.strftime("%Y%m")
+DOWNLOAD_JC        = False
+
+# Data processing constants
+YEARLY_CUTOFF         = 2023   # Files with only a year <= this are assumed to cover the full year
+PARQUET_COMPRESSION   = "zstd"
+STREET_CIRCUITY_FACTOR = 1.3
+
+# Weather retrieval settings
+NYC_COORDS       = (40.7823234, -73.9654161)
+WEATHER_TIMEZONE = "America/New_York"

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -17,7 +17,7 @@ from utils.weather import download_weather_data
 from utils.bike_routes import download_bike_routes
 from utils.pg_loader import assert_no_coverage_gaps, get_loaded_months, init_db, load_stats_for_month, load_weather_hourly, update_dataset_coverage, upsert_station_metadata_from_gbfs
 from scripts.utils.db_loaders.bike_routes import upsert_bike_routes
-from src.backend.config import (
+from config import (
     DATA_DIR,
     RIDES_DATA_DIR,
     WEATHER_DATA_DIR,

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 from utils.pg_loader import init_db
 from utils.db_loaders.hourly_stats import insert_stats_hourly
 from utils.db_loaders.station_activity_hourly import insert_station_activity_hourly
+from utils.db_loaders.station_activity_preagg import insert_station_activity_preagg
 from utils.db_loaders.flow_activity_monthly import insert_flow_activity_monthly
 from utils.db_loaders.station_metadata import upsert_station_metadata
 from utils.db_loaders.weather_hourly import upsert_weather_hourly
@@ -78,6 +79,7 @@ def main() -> None:
         rides = _build_rides(TEST_DATA_DIR / "trips.csv", TEST_DATA_DIR / "distances.csv")
         insert_stats_hourly(conn, rides)
         insert_station_activity_hourly(conn, rides)
+        insert_station_activity_preagg(conn, rides)
         insert_flow_activity_monthly(conn, rides)
         conn.commit()
 

--- a/scripts/utils/bike_routes.py
+++ b/scripts/utils/bike_routes.py
@@ -4,7 +4,7 @@ import polars as pl
 from pathlib import Path
 from datetime import datetime, timezone
 
-from src.backend.config import BIKE_ROUTES_URL, BIKE_ROUTES_PATH, PARQUET_COMPRESSION
+from config import BIKE_ROUTES_URL, BIKE_ROUTES_PATH, PARQUET_COMPRESSION
 
 def _fetch_bike_routes_csv() -> pl.DataFrame:
     """Fetch bike routes CSV bytes over HTTPS and parse with Polars."""

--- a/scripts/utils/db_loaders/station_activity_preagg.py
+++ b/scripts/utils/db_loaders/station_activity_preagg.py
@@ -1,0 +1,88 @@
+import polars as pl
+
+
+def insert_station_activity_preagg(conn, rides: pl.DataFrame) -> None:
+    rides = rides.with_columns([
+        pl.col("date").dt.year().cast(pl.Int16).alias("year"),
+        pl.col("date").dt.month().cast(pl.Int16).alias("month"),
+    ])
+    _insert_by_month(conn, rides)
+    _insert_by_hour(conn, rides)
+    _insert_by_dow(conn, rides)
+
+
+def _build_activity(rides: pl.DataFrame, key_cols: list[str]) -> pl.DataFrame:
+    outgoing = (
+        rides.group_by([*key_cols, "start_station_id"])
+        .agg(pl.len().alias("outgoing_rides"))
+        .rename({"start_station_id": "station_id"})
+    )
+    incoming = (
+        rides.group_by([*key_cols, "end_station_id"])
+        .agg(pl.len().alias("incoming_rides"))
+        .rename({"end_station_id": "station_id"})
+    )
+    return (
+        outgoing.join(incoming, on=[*key_cols, "station_id"], how="full", coalesce=True)
+        .with_columns([pl.col("outgoing_rides").fill_null(0), pl.col("incoming_rides").fill_null(0)])
+    )
+
+
+def _insert_by_month(conn, rides: pl.DataFrame) -> None:
+    activity = _build_activity(rides, ["year", "month", "member_casual", "rideable_type"])
+    rows = [
+        (int(r["year"]), int(r["month"]), r["station_id"], r["member_casual"], r["rideable_type"],
+         int(r["outgoing_rides"]), int(r["incoming_rides"]))
+        for r in activity.iter_rows(named=True)
+    ]
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO station_activity_by_month
+                (year, month, station_id, user_type, bike_type, outgoing_rides, incoming_rides)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (year, month, station_id, user_type, bike_type) DO NOTHING
+            """,
+            rows,
+        )
+    print(f"[DB-LOAD: station_activity_by_month] Inserted {len(rows)} rows")
+
+
+def _insert_by_hour(conn, rides: pl.DataFrame) -> None:
+    activity = _build_activity(rides, ["year", "month", "hour", "member_casual", "rideable_type"])
+    rows = [
+        (int(r["year"]), int(r["month"]), int(r["hour"]), r["station_id"], r["member_casual"], r["rideable_type"],
+         int(r["outgoing_rides"]), int(r["incoming_rides"]))
+        for r in activity.iter_rows(named=True)
+    ]
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO station_activity_by_hour
+                (year, month, hour, station_id, user_type, bike_type, outgoing_rides, incoming_rides)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (year, month, hour, station_id, user_type, bike_type) DO NOTHING
+            """,
+            rows,
+        )
+    print(f"[DB-LOAD: station_activity_by_hour] Inserted {len(rows)} rows")
+
+
+def _insert_by_dow(conn, rides: pl.DataFrame) -> None:
+    activity = _build_activity(rides, ["year", "month", "day_of_week", "member_casual", "rideable_type"])
+    rows = [
+        (int(r["year"]), int(r["month"]), int(r["day_of_week"]), r["station_id"], r["member_casual"], r["rideable_type"],
+         int(r["outgoing_rides"]), int(r["incoming_rides"]))
+        for r in activity.iter_rows(named=True)
+    ]
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO station_activity_by_dow
+                (year, month, day_of_week, station_id, user_type, bike_type, outgoing_rides, incoming_rides)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (year, month, day_of_week, station_id, user_type, bike_type) DO NOTHING
+            """,
+            rows,
+        )
+    print(f"[DB-LOAD: station_activity_by_dow] Inserted {len(rows)} rows")

--- a/scripts/utils/distances.py
+++ b/scripts/utils/distances.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from src.backend.services.gbfs import fetch_station_data
-from src.backend.config import STREET_CIRCUITY_FACTOR, PARQUET_COMPRESSION, STATION_DISTANCES_PATH
+from config import STREET_CIRCUITY_FACTOR, PARQUET_COMPRESSION, STATION_DISTANCES_PATH
 
 def _check_freshness(file_path: Path, max_age_days: int = 30) -> bool:
     """

--- a/scripts/utils/pg_loader.py
+++ b/scripts/utils/pg_loader.py
@@ -6,12 +6,13 @@ plus station_metadata and dataset_coverage.
 """
 import polars as pl
 
-from src.backend.config import RIDES_DATA_DIR, STATION_DISTANCES_PATH, WEATHER_DATA_DIR
+from config import RIDES_DATA_DIR, STATION_DISTANCES_PATH, WEATHER_DATA_DIR
 from src.backend.services.gbfs import fetch_station_data
 from utils.distances import enrich_with_distances
 from utils.db_loaders.flow_activity_monthly import insert_flow_activity_monthly
 from utils.db_loaders.hourly_stats import insert_stats_hourly
 from utils.db_loaders.station_activity_hourly import insert_station_activity_hourly
+from utils.db_loaders.station_activity_preagg import insert_station_activity_preagg
 from utils.db_loaders.station_metadata import upsert_station_metadata
 from utils.db_loaders.weather_hourly import upsert_weather_hourly
 
@@ -55,6 +56,7 @@ def load_stats_for_month(conn, year: int, month: int) -> None:
 
 	insert_stats_hourly(conn, rides)
 	insert_station_activity_hourly(conn, rides)
+	insert_station_activity_preagg(conn, rides)
 	insert_flow_activity_monthly(conn, rides)
 	conn.commit()
 	print(f"  Done — {year}-{month:02d} committed.")
@@ -128,3 +130,4 @@ def get_loaded_months(conn) -> list[int]:
             GROUP BY 1, 2
         """)
         return [y * 100 + m for y, m in cur.fetchall()]
+

--- a/scripts/utils/rides.py
+++ b/scripts/utils/rides.py
@@ -3,10 +3,8 @@ import os
 import requests
 import zipfile
 import polars as pl
-from src.backend.config import PARQUET_COMPRESSION, YEARLY_CUTOFF
+from config import PARQUET_COMPRESSION, YEARLY_CUTOFF, BASE_URL_RIDE_DATA, RIDES_DATA_DIR
 import xml.etree.ElementTree as ET
-
-from src.backend.config import BASE_URL_RIDE_DATA, RIDES_DATA_DIR
 
 def _get_response(url: str, stream: bool = False) -> requests.Response:
     """Execute HTTP GET and raise for non-2xx responses."""

--- a/scripts/utils/weather.py
+++ b/scripts/utils/weather.py
@@ -3,7 +3,7 @@ import polars as pl
 from calendar import monthrange
 from datetime import date, timedelta
 
-from src.backend.config import WEATHER_API_URL, NYC_COORDS, WEATHER_TIMEZONE, PARQUET_COMPRESSION, WEATHER_DATA_DIR
+from config import WEATHER_API_URL, NYC_COORDS, WEATHER_TIMEZONE, PARQUET_COMPRESSION, WEATHER_DATA_DIR
 
 def _get_date_range(min_date: str, max_date: str) -> tuple[date, date]:
     """

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,55 +1,20 @@
-from pathlib import Path
 import logging
-from datetime import datetime, timedelta
+from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
 BACKEND_ROOT = Path(__file__).resolve().parent
 
-# Base URL for the S3 bucket containing the ride data files
-BASE_URL_RIDE_DATA = "https://s3.amazonaws.com/tripdata/"
-WEATHER_API_URL = "https://archive-api.open-meteo.com/v1/archive"
-
-# URL for downloading bike route data from NYC Open Data
-BIKE_ROUTES_URL = "https://data.cityofnewyork.us/api/views/mzxg-pwib/rows.csv?accessType=DOWNLOAD"
-
-# URLs provided by Lyft's GBFS feed
-INFO_URL = "https://gbfs.lyft.com/gbfs/2.3/bkn/en/station_information.json"
+# GBFS feed URLs (Lyft/Citi Bike)
+INFO_URL   = "https://gbfs.lyft.com/gbfs/2.3/bkn/en/station_information.json"
 STATUS_URL = "https://gbfs.lyft.com/gbfs/2.3/bkn/en/station_status.json"
 
-# Cache settings for GBFS data
-TTL_SECONDS = 60  # Cache time-to-live in seconds
-# Note: The GBFS feed provides a "vehicle_types_available" field which is a list of dicts containing bike counts by type. 
-# Each dict has a "vehicle_type_id" (e.g. "1" for classic bikes, "2" for e-bikes) and a "count".
+# GBFS cache and type constants
+TTL_SECONDS              = 60
 GBFS_CLASSIC_BIKE_TYPE_ID = "1"
-GBFS_EBIKE_TYPE_ID = "2"
+GBFS_EBIKE_TYPE_ID        = "2"
 
-# Path to directories and files
-DATA_DIR = PROJECT_ROOT / "data"
-RIDES_DATA_DIR = DATA_DIR / "rides"             # Directory for processed ride data
-WEATHER_DATA_DIR = DATA_DIR / "weather"         # Directory for processed weather data
-STATION_DATA_DIR = DATA_DIR / "stations"        # Directory for precomputed station-pair distances
-STATION_DISTANCES_PATH = STATION_DATA_DIR / "station_pair_distances.parquet"
-BIKE_ROUTES_DATA_DIR = DATA_DIR / "bike_routes" # Directory for preprocessed bike route data
-BIKE_ROUTES_PATH = BIKE_ROUTES_DATA_DIR / "bike_routes.parquet"
-DAILY_STATS_DATA_DIR = DATA_DIR / "daily_stats"  # Directory for precomputed daily stats
-DAILY_STATS_PATH = DAILY_STATS_DATA_DIR / "daily_stats.parquet"
-
-# Setting for weather data retrieval
-NYC_COORDS = (40.7823234, -73.9654161)
-WEATHER_TIMEZONE = "America/New_York"
-
-# Default parameters for data processing and retrieval
-DEFAULT_START_DATE = "202501"
-# The default end date is set to the YYYYMM of the previous month
-one_month_ago = datetime.now() - timedelta(days=30)
-DEFAULT_END_DATE = one_month_ago.strftime("%Y%m")
-DOWNLOAD_JC = False
-YEARLY_CUTOFF = 2023        # If a file name contains only a year <= this cutoff, we assume it covers the entire year
-PARQUET_COMPRESSION = "zstd"
-STREET_CIRCUITY_FACTOR = 1.3
-
-TEST_DATA_DIR = BACKEND_ROOT / "tests" / "test_data"
-
-# Log file settings
+# Logging
 LOG_FILE_PATH = "logs/requests.log"
-LOG_LEVEL = logging.INFO            # To disable logging, set to logging.CRITICAL or higher
+LOG_LEVEL     = logging.INFO
+
+# Test fixtures
+TEST_DATA_DIR = BACKEND_ROOT / "tests" / "test_data"

--- a/src/backend/services/stats/station_ride_counts.py
+++ b/src/backend/services/stats/station_ride_counts.py
@@ -23,36 +23,79 @@ def get_station_ride_counts_stats(
     start_date = datetime.date(start_year, start_month, 1)
     end_date = datetime.date(end_year + (end_month == 12), end_month % 12 + 1, 1)
 
-    if group_by == StationRideGroupBy.NONE:
-        spine_dim  = ""
-        spine_grp  = ""
-        sah_sel    = ""
-        sah_grp    = ", s.hours_count"
-        spine_join = "CROSS JOIN spine s"
-    elif group_by == StationRideGroupBy.DAY_OF_WEEK:
-        spine_dim  = "day_of_week, "
-        spine_grp  = "GROUP BY day_of_week"
-        sah_sel    = ", sah.day_of_week"
-        sah_grp    = ", sah.day_of_week, s.hours_count"
-        spine_join = "JOIN spine s ON s.day_of_week = sah.day_of_week"
+    # Pick the smallest pre-aggregated table that satisfies the query shape.
+    # Falls back to station_activity_hourly only when both day_of_week and hour are needed.
+    if group_by == StationRideGroupBy.DAY_OF_WEEK_AND_HOUR:
+        table       = "station_activity_hourly"
+        spine_dim   = "day_of_week, hour, "
+        spine_grp   = "GROUP BY day_of_week, hour"
+        spine_extra = ""
+        sah_sel     = ", sah.day_of_week, sah.hour"
+        sah_grp     = ", sah.day_of_week, sah.hour, s.hours_count"
+        spine_join  = "JOIN spine s ON s.day_of_week = sah.day_of_week AND s.hour = sah.hour"
+        has_dow_col = True
+    elif group_by == StationRideGroupBy.HOUR and day_of_week is not None:
+        # Need to filter by dow AND group by hour — only the full table has both columns
+        table       = "station_activity_hourly"
+        spine_dim   = "hour, "
+        spine_grp   = "GROUP BY hour"
+        spine_extra = "AND day_of_week = %s"
+        sah_sel     = ", sah.hour"
+        sah_grp     = ", sah.hour, s.hours_count"
+        spine_join  = "JOIN spine s ON s.hour = sah.hour"
+        has_dow_col = True
     elif group_by == StationRideGroupBy.HOUR:
-        spine_dim  = "hour, "
-        spine_grp  = "GROUP BY hour"
-        sah_sel    = ", sah.hour"
-        sah_grp    = ", sah.hour, s.hours_count"
-        spine_join = "JOIN spine s ON s.hour = sah.hour"
-    elif group_by == StationRideGroupBy.DAY_OF_WEEK_AND_HOUR:
-        spine_dim  = "day_of_week, hour, "
-        spine_grp  = "GROUP BY day_of_week, hour"
-        sah_sel    = ", sah.day_of_week, sah.hour"
-        sah_grp    = ", sah.day_of_week, sah.hour, s.hours_count"
-        spine_join = "JOIN spine s ON s.day_of_week = sah.day_of_week AND s.hour = sah.hour"
+        table       = "station_activity_by_hour"
+        spine_dim   = "hour, "
+        spine_grp   = "GROUP BY hour"
+        spine_extra = ""
+        sah_sel     = ", sah.hour"
+        sah_grp     = ", sah.hour, s.hours_count"
+        spine_join  = "JOIN spine s ON s.hour = sah.hour"
+        has_dow_col = False
+    elif group_by == StationRideGroupBy.DAY_OF_WEEK:
+        table       = "station_activity_by_dow"
+        spine_dim   = "day_of_week, "
+        spine_grp   = "GROUP BY day_of_week"
+        spine_extra = ""
+        sah_sel     = ", sah.day_of_week"
+        sah_grp     = ", sah.day_of_week, s.hours_count"
+        spine_join  = "JOIN spine s ON s.day_of_week = sah.day_of_week"
+        has_dow_col = True
+    elif day_of_week is not None:
+        # NONE group_by with a dow filter: by_dow is small and has the column
+        table       = "station_activity_by_dow"
+        spine_dim   = ""
+        spine_grp   = ""
+        spine_extra = "AND day_of_week = %s"
+        sah_sel     = ""
+        sah_grp     = ", s.hours_count"
+        spine_join  = "CROSS JOIN spine s"
+        has_dow_col = True
+    else:
+        # NONE group_by, no dow filter: smallest possible table
+        table       = "station_activity_by_month"
+        spine_dim   = ""
+        spine_grp   = ""
+        spine_extra = ""
+        sah_sel     = ""
+        sah_grp     = ", s.hours_count"
+        spine_join  = "CROSS JOIN spine s"
+        has_dow_col = False
+
+    spine_params = [start_date, end_date]
+    if spine_extra:
+        spine_params.append(day_of_week)
+
+    dow_where  = "AND (%s IS NULL OR sah.day_of_week = %s)" if has_dow_col else ""
+    dow_params = (day_of_week, day_of_week) if has_dow_col else ()
 
     sql = f"""
         WITH spine AS (
             SELECT {spine_dim}COUNT(*) AS hours_count
             FROM weather_hourly
             WHERE date >= %s AND date < %s
+            {spine_extra}
             {spine_grp}
         )
         SELECT sah.station_id, sm.station_name, sm.lat, sm.lon{sah_sel},
@@ -60,30 +103,30 @@ def get_station_ride_counts_stats(
                SUM(sah.incoming_rides) AS incoming_rides,
                SUM(sah.outgoing_rides + sah.incoming_rides) AS total_rides,
                s.hours_count
-        FROM station_activity_hourly sah
+        FROM {table} sah
         JOIN station_metadata sm ON sm.station_id = sah.station_id
         {spine_join}
         WHERE (sah.year, sah.month) >= (%s, %s) AND (sah.year, sah.month) <= (%s, %s)
           AND (%s IS NULL OR sah.station_id = %s)
           AND (%s IS NULL OR sah.user_type = %s)
           AND (%s IS NULL OR sah.bike_type = %s)
-          AND (%s IS NULL OR sah.day_of_week = %s)
+          {dow_where}
         GROUP BY sah.station_id, sm.station_name, sm.lat, sm.lon{sah_grp}
     """
     params = (
-        start_date, end_date,
+        *spine_params,
         start_year, start_month, end_year, end_month,
         station_id, station_id,
         user_val, user_val,
         bike_val, bike_val,
-        day_of_week, day_of_week,
+        *dow_params,
     )
 
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(sql, params)
             rows = fetch_rows(cur)
-
+    
     by_station: dict[str, dict] = {}
     for r in rows:
         sid = r["station_id"]


### PR DESCRIPTION
When querying for a wide time range of data, the responses for the station counts endpoints became slower than expected. To fix this issues, we created different tables with different data granularity to try addressing the issue.

Also, now the configuration constants are splitted into two different files, based on their concerns.