### PR TITLE
Fix download script; update bike routes data

### DIFF
--- a/postgres/schemas/006_bike_routes.sql
+++ b/postgres/schemas/006_bike_routes.sql
@@ -1,11 +1,14 @@
 CREATE TABLE IF NOT EXISTS bike_routes (
-    segmentid   INTEGER      PRIMARY KEY,
-    bikeid      INTEGER      NOT NULL,
-    the_geom    TEXT         NOT NULL,
-    street      VARCHAR(500) NOT NULL,
-    fromstreet  VARCHAR(500) NOT NULL,
-    tostreet    VARCHAR(500) NOT NULL,
-    facilitycl  VARCHAR(5)   NOT NULL,
-    instdate    DATE,
-    boro        VARCHAR(20)
+    segmentid           INTEGER      PRIMARY KEY,
+    bikeid              INTEGER      NOT NULL,
+    status              VARCHAR(20)  NOT NULL,
+    installation_date   DATE         NOT NULL,
+    retired_date        DATE,
+    the_geom            TEXT         NOT NULL,
+    street              VARCHAR(500) NOT NULL,
+    fromstreet          VARCHAR(500) NOT NULL,
+    tostreet            VARCHAR(500) NOT NULL,
+    facilitycl          VARCHAR(5)   NOT NULL,
+    instdate            DATE,
+    boro                VARCHAR(20)
 );

--- a/scripts/utils/bike_routes.py
+++ b/scripts/utils/bike_routes.py
@@ -23,14 +23,10 @@ def _fetch_bike_routes_csv() -> pl.DataFrame:
     return pl.read_csv(io.BytesIO(response.content))
 
 def _clean_bike_data(df: pl.DataFrame) -> pl.DataFrame:
-    # Filter to current facilities only (note capital C)
-    df = df.filter(pl.col('status') == 'Current')
-
+    
     # Drop columns unused by the frontend
     df = df.drop([
         'prevbikeid',
-        'status',       # redundant after filtering
-        'ret_date',     # null for all current records
         'gwsys2',       # sparsely populated
         'spur',         # sparsely populated
         'ft2facilit',   # complex corridors only

--- a/scripts/utils/db_loaders/bike_routes.py
+++ b/scripts/utils/db_loaders/bike_routes.py
@@ -9,6 +9,9 @@ def upsert_bike_routes(conn, df: pl.DataFrame) -> None:
     - df: Polars DataFrame containing bike route data with columns:
         - segmentid (int)
         - bikeid (int)
+        - status (str, e.g. "Current")
+        - instdate (date)
+        - ret_date (date or null)
         - the_geom (str)
         - street (str)
         - fromstreet (str)
@@ -21,7 +24,7 @@ def upsert_bike_routes(conn, df: pl.DataFrame) -> None:
         pl.col("instdate").str.strptime(pl.Date, "%m/%d/%Y", strict=False)
     )
     rows = [
-        (int(r["segmentid"]), int(r["bikeid"]), r["the_geom"], r["street"], r["fromstreet"],
+        (int(r["segmentid"]), int(r["bikeid"]), r["status"], r["instdate"] ,r["ret_date"], r["the_geom"], r["street"], r["fromstreet"],
          r["tostreet"], r["facilitycl"], r["instdate"], r["boro"])
         for r in df.iter_rows(named=True)
     ]
@@ -29,10 +32,13 @@ def upsert_bike_routes(conn, df: pl.DataFrame) -> None:
         cur.executemany(
             """
             INSERT INTO bike_routes
-                (segmentid, bikeid, the_geom, street, fromstreet, tostreet, facilitycl, instdate, boro)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                (segmentid, bikeid, status, installation_date, retired_date, the_geom, street, fromstreet, tostreet, facilitycl, instdate, boro)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (segmentid) DO UPDATE SET
                 bikeid     = EXCLUDED.bikeid,
+                status     = EXCLUDED.status,
+                installation_date = EXCLUDED.installation_date,
+                retired_date = EXCLUDED.retired_date,
                 the_geom   = EXCLUDED.the_geom,
                 street     = EXCLUDED.street,
                 fromstreet = EXCLUDED.fromstreet,

--- a/scripts/utils/rides.py
+++ b/scripts/utils/rides.py
@@ -165,6 +165,7 @@ def _download_and_process_file(file_key: str, base_data_url: str) -> pl.DataFram
     # Check if the file exists in the S3 bucket before attempting to download
     response = requests.get(base_data_url + file_key, stream=True)
     response.raise_for_status()
+
     # Get the total size of the file for progress tracking
     total_size = int(response.headers.get("content-length", 0))
     downloaded_size = 0
@@ -207,22 +208,49 @@ def _download_and_process_file(file_key: str, base_data_url: str) -> pl.DataFram
     buffer.seek(0)
     csv_frames = []
     
-    with zipfile.ZipFile(buffer) as zip_file:
-        for name in zip_file.namelist():
-            if name.endswith(".csv"):
-                csv_name = os.path.basename(name)
-                print(f"[PROCESS] Reading {csv_name}")
-                with zip_file.open(name) as source:
-                    csv_frames.append(
-                        pl.read_csv(
-                            source,
-                            # Override the schema for station ID columns to ensure string type
-                            schema_overrides={
-                                "start_station_id": pl.Utf8,
-                                "end_station_id": pl.Utf8,
-                            },
+    with zipfile.ZipFile(buffer) as outer_zip:
+        names = outer_zip.namelist()
+        has_inner_zips = any(n.endswith(".zip") for n in names)
+
+        if has_inner_zips:
+            # Pre-202401 yearly format: outer zip contains monthly inner zips
+            print("[PROCESS] Detected nested ZIP structure (yearly format)")
+            for inner_name in names:
+                if not inner_name.endswith(".zip"):
+                    continue
+                print(f"[PROCESS] Opening inner ZIP {os.path.basename(inner_name)}")
+                with outer_zip.open(inner_name) as inner_raw:
+                    inner_bytes = io.BytesIO(inner_raw.read())
+                with zipfile.ZipFile(inner_bytes) as inner_zip:
+                    for csv_name in inner_zip.namelist():
+                        if csv_name.endswith(".csv"):
+                            print(f"[PROCESS] Reading {os.path.basename(csv_name)}")
+                            with inner_zip.open(csv_name) as source:
+                                csv_frames.append(
+                                    pl.read_csv(
+                                        source,
+                                        schema_overrides={
+                                            "start_station_id": pl.Utf8,
+                                            "end_station_id": pl.Utf8,
+                                        },
+                                    )
+                                )
+        else:
+            # Post-202401 monthly format: outer zip contains CSVs directly
+            for name in names:
+                if name.endswith(".csv"):
+                    csv_name = os.path.basename(name)
+                    print(f"[PROCESS] Reading {csv_name}")
+                    with outer_zip.open(name) as source:
+                        csv_frames.append(
+                            pl.read_csv(
+                                source,
+                                schema_overrides={
+                                    "start_station_id": pl.Utf8,
+                                    "end_station_id": pl.Utf8,
+                                },
+                            )
                         )
-                    )
     
     if not csv_frames:
         print("[WARN] No CSV files found in ZIP")

--- a/src/backend/models/bike_route.py
+++ b/src/backend/models/bike_route.py
@@ -26,4 +26,6 @@ class BikeRoute(BaseModel):
     fromStreet: str
     toStreet: str
     facilityClass: FacilityClass
-    instDate: date | None = None
+    instDate: date
+    retiredDate: date | None
+    boro: str

--- a/src/backend/routes/bike_routes.py
+++ b/src/backend/routes/bike_routes.py
@@ -1,11 +1,17 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 from src.backend.models.bike_route import BikeRoute
-from src.backend.services.bike_routes import load_bike_routes
+from src.backend.services.bike_routes import load_bike_routes, load_bike_routes_for_year
+
 router = APIRouter(prefix="/bike_routes", tags=["bike_routes"])
 
 @router.get("/", response_model=list[BikeRoute])
 def get_bike_routes():
-    """Endpoint to retrieve all bike route segments."""
+    """Retrieve all bike route segments."""
     return load_bike_routes()
-    
+
+@router.get("/history", response_model=list[BikeRoute])
+def get_bike_routes_history(year: int = Query(..., ge=1900, description="Year to query active bike routes for")):
+    """Retrieve bike route segments that were active at any point during the given year."""
+    return load_bike_routes_for_year(year)
+

--- a/src/backend/services/bike_routes.py
+++ b/src/backend/services/bike_routes.py
@@ -1,6 +1,12 @@
 import re
+from datetime import date
 from src.backend.db import get_conn
 from src.backend.models.bike_route import BikeRoute, BikeSegmentGeometry, GeometryType
+
+_SELECT = (
+    "SELECT bikeid, the_geom, street, fromstreet, tostreet, facilitycl, instdate, retired_date, boro "
+    "FROM bike_routes"
+)
 
 def _parse_wkt_multilinestring(wkt: str) -> list[list[list[float]]]:
     """Parse a MultiLineString WKT into a list of line segments, each a list of [lng, lat] pairs."""
@@ -16,17 +22,7 @@ def _parse_wkt_linestring(wkt: str) -> list[list[float]]:
     coord_re = r"(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s+(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)"
     return [[float(lng), float(lat)] for lng, lat in re.findall(coord_re, wkt)]
 
-def load_bike_routes() -> list[BikeRoute]:
-    """Fetch all bike route segments from PostgreSQL and return as BikeRoute objects."""
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                "SELECT bikeid, the_geom, street, fromstreet, tostreet, facilitycl, instdate "
-                "FROM bike_routes"
-            )
-            cols = [d[0] for d in cur.description]
-            rows = [dict(zip(cols, row)) for row in cur.fetchall()]
-
+def _rows_to_bike_routes(rows: list[dict]) -> list[BikeRoute]:
     return [
         BikeRoute(
             geometry=BikeSegmentGeometry(
@@ -39,6 +35,34 @@ def load_bike_routes() -> list[BikeRoute]:
             toStreet=row["tostreet"],
             facilityClass=row["facilitycl"],
             instDate=row["instdate"],
+            retiredDate=row["retired_date"],
+            boro=row["boro"],
         )
         for row in rows
     ]
+
+def load_bike_routes(current_only: bool = False) -> list[BikeRoute]:
+    """Fetch bike route segments from PostgreSQL. Pass current_only=True to limit to active routes."""
+    query = _SELECT + (" WHERE status = 'Current'" if current_only else "")
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query)
+            cols = [d[0] for d in cur.description]
+            rows = [dict(zip(cols, row)) for row in cur.fetchall()]
+    return _rows_to_bike_routes(rows)
+
+def load_bike_routes_for_year(year: int) -> list[BikeRoute]:
+    """Return routes that were active at any point during the given year."""
+    year_start = date(year, 1, 1)
+    year_end   = date(year, 12, 31)
+    query = (
+        _SELECT
+        + " WHERE installation_date <= %s"
+        "   AND (retired_date IS NULL OR retired_date >= %s)"
+    )
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (year_end, year_start))
+            cols = [d[0] for d in cur.description]
+            rows = [dict(zip(cols, row)) for row in cur.fetchall()]
+    return _rows_to_bike_routes(rows)


### PR DESCRIPTION
- Download script was updated to now also correctly consider the case of dataset from 2023 and previous years. The zip folder was published each year and each zip contained a single zip for each month. Previously, this case was not considered;
- Modify the bike routes data so that it keeps historical data also. Endpoints are updated. The previous one remains untouched only returning current active counts. A new historical one is added, which returns routes data active at a certain year