### PR TITLE
fix pipeline memory leak; changed station ID from VARCHAR to TEXT

### DIFF
--- a/postgres/schemas/001_stats_hourly.sql
+++ b/postgres/schemas/001_stats_hourly.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS stats_hourly (
     hour                    SMALLINT         NOT NULL,
     day_of_week             SMALLINT         NOT NULL,
     user_type               VARCHAR(10)      NOT NULL,
-    bike_type               VARCHAR(20)      NOT NULL,
+    bike_type               VARCHAR(50)      NOT NULL,
     total_rides             BIGINT           NOT NULL DEFAULT 0,
     total_duration_seconds  DOUBLE PRECISION NOT NULL DEFAULT 0,
     total_distance_km       DOUBLE PRECISION NOT NULL DEFAULT 0,

--- a/postgres/schemas/002_station_activity_hourly.sql
+++ b/postgres/schemas/002_station_activity_hourly.sql
@@ -6,9 +6,9 @@ CREATE TABLE IF NOT EXISTS station_activity_hourly (
     month           SMALLINT     NOT NULL,
     day_of_week     SMALLINT     NOT NULL,
     hour            SMALLINT     NOT NULL,
-    station_id      VARCHAR(20)  NOT NULL,
+    station_id      TEXT         NOT NULL,
     user_type       VARCHAR(10)  NOT NULL,
-    bike_type       VARCHAR(20)  NOT NULL,
+    bike_type       VARCHAR(50)  NOT NULL,
     outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
     incoming_rides  INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, day_of_week, hour, station_id, user_type, bike_type)
@@ -21,9 +21,9 @@ CREATE TABLE IF NOT EXISTS station_activity_hourly (
 CREATE TABLE IF NOT EXISTS station_activity_by_month (
     year            SMALLINT     NOT NULL,
     month           SMALLINT     NOT NULL,
-    station_id      VARCHAR(20)  NOT NULL,
+    station_id      TEXT         NOT NULL,
     user_type       VARCHAR(10)  NOT NULL,
-    bike_type       VARCHAR(20)  NOT NULL,
+    bike_type       VARCHAR(50)  NOT NULL,
     outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
     incoming_rides  INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, station_id, user_type, bike_type)
@@ -34,9 +34,9 @@ CREATE TABLE IF NOT EXISTS station_activity_by_hour (
     year            SMALLINT     NOT NULL,
     month           SMALLINT     NOT NULL,
     hour            SMALLINT     NOT NULL,
-    station_id      VARCHAR(20)  NOT NULL,
+    station_id      TEXT         NOT NULL,
     user_type       VARCHAR(10)  NOT NULL,
-    bike_type       VARCHAR(20)  NOT NULL,
+    bike_type       VARCHAR(50)  NOT NULL,
     outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
     incoming_rides  INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, hour, station_id, user_type, bike_type)
@@ -47,9 +47,9 @@ CREATE TABLE IF NOT EXISTS station_activity_by_dow (
     year            SMALLINT     NOT NULL,
     month           SMALLINT     NOT NULL,
     day_of_week     SMALLINT     NOT NULL,
-    station_id      VARCHAR(20)  NOT NULL,
+    station_id      TEXT         NOT NULL,
     user_type       VARCHAR(10)  NOT NULL,
-    bike_type       VARCHAR(20)  NOT NULL,
+    bike_type       VARCHAR(50)  NOT NULL,
     outgoing_rides  INTEGER      NOT NULL DEFAULT 0,
     incoming_rides  INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, day_of_week, station_id, user_type, bike_type)

--- a/postgres/schemas/003_flow_activity_monthly.sql
+++ b/postgres/schemas/003_flow_activity_monthly.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS flow_activity_monthly (
     year            SMALLINT     NOT NULL,
     month           SMALLINT     NOT NULL,
-    station_a_id    VARCHAR(20)  NOT NULL,
-    station_b_id    VARCHAR(20)  NOT NULL,
+    station_a_id    TEXT         NOT NULL,
+    station_b_id    TEXT         NOT NULL,
     user_type       VARCHAR(10)  NOT NULL,
-    bike_type       VARCHAR(20)  NOT NULL,
+    bike_type       VARCHAR(50)  NOT NULL,
     a_to_b_count    INTEGER      NOT NULL DEFAULT 0,
     b_to_a_count    INTEGER      NOT NULL DEFAULT 0,
     PRIMARY KEY (year, month, station_a_id, station_b_id, user_type, bike_type)

--- a/postgres/schemas/004_station_metadata.sql
+++ b/postgres/schemas/004_station_metadata.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS station_metadata (
-    station_id    VARCHAR(20) PRIMARY KEY,
+    station_id    TEXT PRIMARY KEY,
     station_name  VARCHAR(200),
     lat           DOUBLE PRECISION,
     lon           DOUBLE PRECISION

--- a/scripts/utils/pg_loader.py
+++ b/scripts/utils/pg_loader.py
@@ -65,7 +65,7 @@ def load_stats_for_month(conn, year: int, month: int) -> None:
 		finally:
 			pconn.close()
 
-	with ThreadPoolExecutor(max_workers=4) as pool:
+	with ThreadPoolExecutor(max_workers=min(4, os.cpu_count() or 1)) as pool:
 		futures = [
 			pool.submit(_run, insert_stats_hourly),
 			pool.submit(_run, insert_station_activity_hourly),

--- a/scripts/utils/rides.py
+++ b/scripts/utils/rides.py
@@ -297,6 +297,7 @@ def download_ride_data(start_date: str, end_date: str, download_jc: bool, curren
         )
 
         # Write the combined DataFrame to a parquet file, partitioned by year and month
+        new_month_pairs = trip_data.select(["year", "month"]).unique().rows()
         trip_data.write_parquet(
             RIDES_DATA_DIR,
             row_group_size=100_000,   # smaller = faster predicate pushdown
@@ -306,5 +307,9 @@ def download_ride_data(start_date: str, end_date: str, download_jc: bool, curren
 
         print(f"[PROCESS] Wrote {trip_data.height} rows → {RIDES_DATA_DIR} ({f})")
 
-        for year, month in trip_data.select(["year", "month"]).unique().rows():
+        # Free the full-year DataFrame before suspending at yields — otherwise it
+        # stays alive in the generator frame across all 12 yield points.
+        del trip_data
+
+        for year, month in new_month_pairs:
             yield year, month


### PR DESCRIPTION
- The download pipeline had issues with memory leaks. When data was downloaded it was kept in memory until it was elaborated. This was changed to fix the starvation problem encountered in the release workflow. Now, after being downloaded, each the Polar data frame is removed from memory;
- Changed station ID from varchar to text. It was shown to cause some issues locally within the pipeline. This should fix the issue 