### PR TITLE
Update repository references and link the notebook docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules/
 /src/frontend/dist
 .github/prompts/plan-polarsParquetStrategy.prompt.md
 CLAUDE.md
+docs/requirements/

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -15,7 +15,7 @@ No need to clone the repository or build anything, Docker will automatically pul
 
 > **Default data range:** The images are built filled with default data starting from January 2020 to the last month updated. If you want to customise the date range, please refer to the [Quick start from source](#quick-start-from-source) section below.
 
-**1. Download `docker-compose.release.yml` from the [latest release](https://github.com/446f6e6e79/nyc-bike-data-visualization/releases/latest)**
+**1. Download `docker-compose.release.yml` from the [latest release](https://github.com/davide-dona/nyc-bike-data-visualization/releases/latest)**
 
 **2. Run it:**
 
@@ -45,7 +45,7 @@ If you want to run the latest code or customise the date range, you can build th
 Clone the repository and start all services with a single command:
 
 ```bash
-git clone https://github.com/446f6e6e79/nyc-bike-data-visualization.git
+git clone https://github.com/davide-dona/nyc-bike-data-visualization.git
 cd nyc-bike-data-visualization
 docker compose up --build
 ```
@@ -107,7 +107,7 @@ DATA_END_DATE=202412
 
 ## Development with a pre-seeded database
 
-Seeding the database locally takes a long time and ~17 GB of disk. For development, CI publishes **pre-seeded database images** to GHCR (`ghcr.io/446f6e6e79/nyc-bike-db`) so you can skip seeding entirely:
+Seeding the database locally takes a long time and ~17 GB of disk. For development, CI publishes **pre-seeded database images** to GHCR (`ghcr.io/davide-dona/nyc-bike-db`) so you can skip seeding entirely:
 
 | Tag | Contents | Size |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Backend Tests](https://github.com/446f6e6e79/nyc-bike-data-visualization/actions/workflows/backend-tests.yml/badge.svg?branch=main)](https://github.com/446f6e6e79/nyc-bike-data-visualization/actions/workflows/backend-tests.yml)
-[![Frontend Tests](https://github.com/446f6e6e79/nyc-bike-data-visualization/actions/workflows/frontend-tests.yml/badge.svg)](https://github.com/446f6e6e79/nyc-bike-data-visualization/actions/workflows/frontend-tests.yml)
+[![Backend Tests](https://github.com/davide-dona/nyc-bike-data-visualization/actions/workflows/backend-tests.yml/badge.svg?branch=main)](https://github.com/davide-dona/nyc-bike-data-visualization/actions/workflows/backend-tests.yml)
+[![Frontend Tests](https://github.com/davide-dona/nyc-bike-data-visualization/actions/workflows/frontend-tests.yml/badge.svg)](https://github.com/davide-dona/nyc-bike-data-visualization/actions/workflows/frontend-tests.yml)
 
 <div align="center">
 
@@ -21,7 +21,7 @@ This project focuses on the visualization of bike-sharing data from New York Cit
 
 The fastest way to run the full application is with the **pre-built release images**: a complete, pre-seeded database and ready-to-run backend and frontend. No clone, no build.
 
-**1. Download `docker-compose.release.yml` from the [latest release](https://github.com/446f6e6e79/nyc-bike-data-visualization/releases/latest).**
+**1. Download `docker-compose.release.yml` from the [latest release](https://github.com/davide-dona/nyc-bike-data-visualization/releases/latest).**
 
 **2. Start everything:**
 
@@ -44,6 +44,7 @@ For development, run a pre-seeded database in Docker and start the backend and f
 
 - [Backend](src/backend/README.md): FastAPI server, PostgreSQL setup, running tests, API docs
 - [Frontend](src/frontend/README.md): React + Vite app, development server, running tests
+- [Dataset exploration](src/notebooks/README.md): EDA notebook behind the technical report (dataset description and data-quality analysis)
 
 ## Repository Structure
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@
 # remove the volume first: docker compose -f docker-compose.dev.yml down -v
 services:
   postgres:
-    image: ghcr.io/446f6e6e79/nyc-bike-db:${DB_TAG:-dev}
+    image: ghcr.io/davide-dona/nyc-bike-db:${DB_TAG:-dev}
     container_name: NYC-Bike-Dev-Postgres
     environment:
       POSTGRES_DB: citibike


### PR DESCRIPTION
Aligns the repository metadata with the current GitHub namespace and points the docs index at the new notebook.

### Changes

- **Repository references:** updated the CI badge, clone, release-download and GHCR image URLs from the old `446f6e6e79` namespace to `davide-dona` across `README.md`, `DOCKER_SETUP.md` and `docker-compose.dev.yml`.
- **Docs index:** added the dataset exploration notebook to the README documentation list.
- **`.gitignore`:** ignore `docs/requirements/`.