### PR TITLE
Group stats query params into shared models and tighten ingestion cleaning

### DIFF
--- a/src/backend/models/bike_route.py
+++ b/src/backend/models/bike_route.py
@@ -13,10 +13,10 @@ class BikeSegmentGeometry(BaseModel):
 
 # Define the FacilityClass enum for the different types of bike facilities
 class FacilityClass(str, Enum):
-    I   = "I"     # Off-street path / greenway
-    II  = "II"    # Dedicated painted lane
-    III = "III"   # Signed shared route
-    L   = "L"     # Shared lane marking (sharrow)
+    I   = "I"     # Protected
+    II  = "II"    # Conventional
+    III = "III"   # Shared Lane or Signed Route
+    L   = "L"     # Link
 
 class BikeRoute(BaseModel):
     """A single NYC bike route segment."""

--- a/src/backend/models/params.py
+++ b/src/backend/models/params.py
@@ -1,0 +1,56 @@
+from datetime import date, timedelta
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field, model_validator
+
+from src.backend.models.ride import MemberCasual, RideableType
+
+class DateRange(BaseModel):
+    """Inclusive date range for stats queries."""
+
+    start_date: date
+    end_date: date
+
+    @model_validator(mode="after")
+    def _check_order(self) -> "DateRange":
+        if self.end_date < self.start_date:
+            raise HTTPException(status_code=422, detail="end_date must not be before start_date")
+        return self
+
+    def bounds(self) -> tuple[date, date]:
+        """Return the [start, end) date bounds for the hours spine."""
+        return self.start_date, self.end_date + timedelta(days=1)
+
+
+class MonthRange(BaseModel):
+    """Inclusive month range for stats queries."""
+
+    start_year: int = Field(ge=2000, le=2100)
+    start_month: int = Field(ge=1, le=12)
+    end_year: int = Field(ge=2000, le=2100)
+    end_month: int = Field(ge=1, le=12)
+
+    @model_validator(mode="after")
+    def _check_order(self) -> "MonthRange":
+        if (self.end_year, self.end_month) < (self.start_year, self.start_month):
+            raise HTTPException(status_code=422, detail="end month must not be before start month")
+        return self
+
+    def bounds(self) -> tuple[date, date]:
+        """Return the [start, end) date bounds for the hours spine."""
+        start = date(self.start_year, self.start_month, 1)
+        end_excl = date(self.end_year + (self.end_month == 12), self.end_month % 12 + 1, 1)
+        return start, end_excl
+
+
+class RideFilters(BaseModel):
+    """Optional ride-level filters shared by the stats endpoints."""
+
+    user_type: MemberCasual | None = None
+    bike_type: RideableType | None = None
+
+
+class StationFilters(RideFilters):
+    """Ride filters plus the station restriction used by the station stats endpoints."""
+
+    station_id: str | None = None

--- a/src/backend/routes/ride_stats.py
+++ b/src/backend/routes/ride_stats.py
@@ -1,7 +1,8 @@
-from datetime import date
-from fastapi import APIRouter, Query
-from src.backend.models.ride import MemberCasual, RideableType
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, Query
+
+from src.backend.models.params import DateRange, RideFilters
 from src.backend.models.ride_stats import StatsGroupBy, Stats, GroupedStats, WeatherVariable
 
 from src.backend.services.ride_stats import get_stats_data
@@ -10,36 +11,19 @@ router = APIRouter(prefix="/stats", tags=["stats"])
 
 @router.get("/", response_model=Stats | list[GroupedStats])
 def get_stats(
+    date_range: Annotated[DateRange, Depends()],
+    filters: Annotated[RideFilters, Depends()],
     group_by: StatsGroupBy = Query(default=StatsGroupBy.NONE),
-    user_type: MemberCasual | None = Query(default=None),
-    bike_type: RideableType | None = Query(default=None),
-    start_date: date = Query(...),
-    end_date: date = Query(...),
 ):
     """Get historical rides stats, optionally grouped by day_of_week, hour, or both."""
-    return get_stats_data(
-        group_by=group_by,
-        user_type=user_type,
-        bike_type=bike_type,
-        start_date=start_date,
-        end_date=end_date,
-    )
+    return get_stats_data(date_range, filters, group_by=group_by)
 
 @router.get("/stats_by_weather", response_model=list[GroupedStats])
 def get_stats_by_weather(
+    date_range: Annotated[DateRange, Depends()],
+    filters: Annotated[RideFilters, Depends()],
     group_by: StatsGroupBy = Query(default=StatsGroupBy.NONE),
     variable: WeatherVariable = Query(default=WeatherVariable.WEATHER_CODE),
-    user_type: MemberCasual | None = Query(default=None),
-    bike_type: RideableType | None = Query(default=None),
-    start_date: date = Query(...),
-    end_date: date = Query(...),
 ):
     """Get historical rides stats bucketed by a weather variable, optionally grouped by day_of_week, hour, or both."""
-    return get_stats_data(
-        group_by=group_by,
-        user_type=user_type,
-        bike_type=bike_type,
-        start_date=start_date,
-        end_date=end_date,
-        weather_var=variable,
-    )
+    return get_stats_data(date_range, filters, group_by=group_by, weather_var=variable)

--- a/src/backend/routes/station_stats.py
+++ b/src/backend/routes/station_stats.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Query
-from src.backend.models.ride import MemberCasual, RideableType
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, Query
+
+from src.backend.models.params import MonthRange, StationFilters
 from src.backend.models.station_stats.flow_counts import StationFlowCounts
 from src.backend.models.station_stats.ride_counts import StationRideCounts, StationRideGroupBy
 
@@ -11,50 +13,28 @@ router = APIRouter(prefix="/stats", tags=["stats"])
 
 @router.get("/station_usage_counts", response_model=list[StationRideCounts])
 def get_station_ride_counts(
+    month_range: Annotated[MonthRange, Depends()],
+    filters: Annotated[StationFilters, Depends()],
     group_by: StationRideGroupBy = Query(default=StationRideGroupBy.NONE),
-    user_type: MemberCasual | None = Query(default=None),
-    bike_type: RideableType | None = Query(default=None),
-    start_year: int = Query(..., ge=2000, le=2100),
-    start_month: int = Query(..., ge=1, le=12),
-    end_year: int = Query(..., ge=2000, le=2100),
-    end_month: int = Query(..., ge=1, le=12),
-    station_id: str | None = Query(default=None),
     day_of_week: int | None = Query(default=None, ge=0, le=6),
     limit: int | None = Query(default=100, ge=1, le=3000)
 ):
     """Get the count of rides starting or ending at each station, optionally grouped by day_of_week, hour, or both."""
     return get_station_ride_counts_stats(
-        group_by=group_by,
-        user_type=user_type,
-        bike_type=bike_type,
-        start_year=start_year,
-        start_month=start_month,
-        end_year=end_year,
-        end_month=end_month,
-        station_id=station_id,
+        month_range,
+        filters,
         day_of_week=day_of_week,
+        group_by=group_by,
         limit=limit,
     )
 
 @router.get("/station_flow_counts", response_model=list[StationFlowCounts])
 def get_trips_between_stations(
-    user_type: MemberCasual | None = Query(default=None),
-    bike_type: RideableType | None = Query(default=None),
-    start_year: int = Query(..., ge=2000, le=2100),
-    start_month: int = Query(..., ge=1, le=12),
-    end_year: int = Query(..., ge=2000, le=2100),
-    end_month: int = Query(..., ge=1, le=12),
-    station_id: str | None = Query(default=None),
-    limit: int | None = Query(default=100, ge=1, le=1000)
+    month_range: Annotated[MonthRange, Depends()],
+    filters: Annotated[StationFilters, Depends()],
+    limit: int | None = Query(default=None, ge=1, le=1000)
 ):
-    """Get the count of rides between each station pair."""
-    return get_trips_between_stations_stats(
-        user_type=user_type,
-        bike_type=bike_type,
-        start_year=start_year,
-        start_month=start_month,
-        end_year=end_year,
-        end_month=end_month,
-        station_id=station_id,
-        limit=limit,
-    )
+    """Get the count of rides between each station pair. When limit is omitted,
+    station-scoped requests return every partner pair; citywide requests are
+    capped server-side."""
+    return get_trips_between_stations_stats(month_range, filters, limit=limit)

--- a/src/backend/services/ride_stats.py
+++ b/src/backend/services/ride_stats.py
@@ -1,12 +1,10 @@
-from datetime import date
 from itertools import product
 
 from src.backend.db import fetch_rows, get_conn
-from src.backend.models.ride import MemberCasual, RideableType
+from src.backend.models.params import DateRange, RideFilters
 from src.backend.models.ride_stats import GroupedStats, Stats, StatsGroupBy, WeatherVariable
 
 from src.backend.services.sql.query_builder import Filters, SpineQueryBuilder
-from src.backend.services.sql.spine import date_range_bounds
 
 # Time dimensions selected by each group_by option. Every dimension exists in the
 # hours spine, so the spine can be built generically.
@@ -20,12 +18,12 @@ _GROUP_DIMS: dict[StatsGroupBy, list[str]] = {
 
 # Bucketing expression over the weather_hourly alias `w`, the output column name,
 # and the source column whose NULLs exclude an hour from the spine and facts.
-# Numeric bins are encoded as their lower edge: temperature in 2 °C steps,
-# precipitation in dry/trace/light/moderate/heavy buckets (mm/h) since uniform
-# bins would put nearly all hours in the dry bucket.
+# Numeric bins are encoded as their lower edge: temperature in whole-degree
+# (1 °C) steps, precipitation in dry/trace/light/moderate/heavy buckets (mm/h)
+# since uniform bins would put nearly all hours in the dry bucket.
 _WEATHER_EXPRS: dict[WeatherVariable, tuple[str, str, str]] = {
     WeatherVariable.WEATHER_CODE: ("w.weather_code", "weather_code", "w.weather_code"),
-    WeatherVariable.TEMPERATURE: ("(floor(w.temperature_2m / 2)::int * 2)", "weather_bin", "w.temperature_2m"),
+    WeatherVariable.TEMPERATURE: ("floor(w.temperature_2m)::int", "weather_bin", "w.temperature_2m"),
     WeatherVariable.PRECIPITATION: (
         "(CASE WHEN w.precipitation <= 0 THEN 0.0"
         " WHEN w.precipitation < 0.5 THEN 0.1"
@@ -35,11 +33,9 @@ _WEATHER_EXPRS: dict[WeatherVariable, tuple[str, str, str]] = {
 }
 
 def get_stats_data(
-    start_date: date,
-    end_date: date,
+    date_range: DateRange,
+    filters: RideFilters,
     group_by: StatsGroupBy = StatsGroupBy.NONE,
-    user_type: MemberCasual | None = None,
-    bike_type: RideableType | None = None,
     weather_var: WeatherVariable | None = None,
 ) -> Stats | list[GroupedStats]:
     """Fetch aggregated stats for rides in the given date range, optionally grouped by time dimensions and/or weather.
@@ -50,16 +46,16 @@ def get_stats_data(
     and the final SELECT groups by the dimensions — which lets it also compute the
     per-hour std aggregates behind the *_std fields.
     """
-    spine_start, spine_end = date_range_bounds(start_date, end_date)
+    spine_start, spine_end = date_range.bounds()
     dims = _GROUP_DIMS[group_by]
 
     f = Filters()
     f.add("sh.date >= %s", spine_start)
     f.add("sh.date < %s", spine_end)
-    if user_type is not None:
-        f.add("sh.user_type = %s", user_type.value)
-    if bike_type is not None:
-        f.add("sh.bike_type = %s", bike_type.value)
+    if filters.user_type is not None:
+        f.add("sh.user_type = %s", filters.user_type.value)
+    if filters.bike_type is not None:
+        f.add("sh.bike_type = %s", filters.bike_type.value)
 
     # The spine always keeps (date, hour) so per-hour ride facts can be joined back;
     # dims that coincide with the join columns must not be selected twice.

--- a/src/backend/services/sql/spine.py
+++ b/src/backend/services/sql/spine.py
@@ -1,7 +1,3 @@
-from datetime import date, timedelta
-
-from fastapi import HTTPException
-
 # Calendar-based spine: one row per hour in [start, end), generated independently
 # of any data table so that time buckets and hours_count never depend on the
 # coverage of other tables. Takes two query params: start (inclusive) and end
@@ -12,17 +8,3 @@ HOURS_CTE = """hours AS (
                    (EXTRACT(ISODOW FROM gs) - 1)::smallint AS day_of_week
             FROM generate_series(%s::timestamp, %s::timestamp - interval '1 hour', interval '1 hour') gs
         )"""
-
-def date_range_bounds(start_date: date, end_date: date) -> tuple[date, date]:
-    """Validate an inclusive date range and return its [start, end) bounds for the hours spine."""
-    if end_date < start_date:
-        raise HTTPException(status_code=422, detail="end_date must not be before start_date")
-    return start_date, end_date + timedelta(days=1)
-
-def month_range_bounds(start_year: int, start_month: int, end_year: int, end_month: int) -> tuple[date, date]:
-    """Validate an inclusive month range and return its [start, end) date bounds for the hours spine."""
-    start = date(start_year, start_month, 1)
-    end_excl = date(end_year + (end_month == 12), end_month % 12 + 1, 1)
-    if end_excl <= start:
-        raise HTTPException(status_code=422, detail="end month must not be before start month")
-    return start, end_excl

--- a/src/backend/services/station_stats/flow_counts.py
+++ b/src/backend/services/station_stats/flow_counts.py
@@ -1,34 +1,35 @@
 from src.backend.db import fetch_rows, get_conn
-from src.backend.models.ride import MemberCasual, RideableType
+from src.backend.models.params import MonthRange, StationFilters
 from src.backend.models.station_stats.flow_counts import GroupedStationFlowCounts, StationFlowCounts
-from src.backend.services.sql.spine import HOURS_CTE, month_range_bounds
+from src.backend.services.sql.query_builder import Filters
+from src.backend.services.sql.spine import HOURS_CTE
+
+# Ceiling applied to citywide (no station_id) requests that omit an explicit
+# limit, so an unbounded query can never dump every pair in the table.
+CITYWIDE_PAIR_CAP = 1000
 
 def get_trips_between_stations_stats(
-    start_year: int,
-    start_month: int,
-    end_year: int,
-    end_month: int,
-    user_type: MemberCasual | None = None,
-    bike_type: RideableType | None = None,
-    station_id: str | None = None,
-    limit: int = 100,
+    month_range: MonthRange,
+    filters: StationFilters,
+    limit: int | None = None,
 ) -> list[StationFlowCounts]:
     """Fetch aggregated counts of trips between station pairs in the given month range,
     following the shared spine pattern: a calendar hours CTE provides hours_count and
-    the top pairs are selected in SQL."""
-    spine_start, spine_end = month_range_bounds(start_year, start_month, end_year, end_month)
+    the top pairs are selected in SQL. A None limit returns every pair for
+    station-scoped requests and falls back to CITYWIDE_PAIR_CAP citywide."""
+    if limit is None and filters.station_id is None:
+        limit = CITYWIDE_PAIR_CAP
+    spine_start, spine_end = month_range.bounds()
 
-    filters = ["(fam.year, fam.month) >= (%s, %s)", "(fam.year, fam.month) <= (%s, %s)"]
-    filter_params: list = [start_year, start_month, end_year, end_month]
-    if station_id is not None:
-        filters.append("(fam.station_a_id = %s OR fam.station_b_id = %s)")
-        filter_params.extend([station_id, station_id])
-    if user_type is not None:
-        filters.append("fam.user_type = %s")
-        filter_params.append(user_type.value)
-    if bike_type is not None:
-        filters.append("fam.bike_type = %s")
-        filter_params.append(bike_type.value)
+    f = Filters()
+    f.add("(fam.year, fam.month) >= (%s, %s)", month_range.start_year, month_range.start_month)
+    f.add("(fam.year, fam.month) <= (%s, %s)", month_range.end_year, month_range.end_month)
+    if filters.station_id is not None:
+        f.add("(fam.station_a_id = %s OR fam.station_b_id = %s)", filters.station_id, filters.station_id)
+    if filters.user_type is not None:
+        f.add("fam.user_type = %s", filters.user_type.value)
+    if filters.bike_type is not None:
+        f.add("fam.bike_type = %s", filters.bike_type.value)
 
     sql = f"""
         WITH {HOURS_CTE},
@@ -50,15 +51,17 @@ def get_trips_between_stations_stats(
         JOIN station_metadata sm_a ON sm_a.station_id = fam.station_a_id
         JOIN station_metadata sm_b ON sm_b.station_id = fam.station_b_id
         CROSS JOIN spine s
-        WHERE {" AND ".join(filters)}
+        WHERE {f.where_sql}
         GROUP BY fam.station_a_id, fam.station_b_id,
                  sm_a.station_name, sm_a.lat, sm_a.lon,
                  sm_b.station_name, sm_b.lat, sm_b.lon,
                  s.hours_count
         ORDER BY total_rides DESC, fam.station_a_id, fam.station_b_id
-        LIMIT %s
+        {"LIMIT %s" if limit is not None else ""}
     """
-    params = (spine_start, spine_end, *filter_params, limit)
+    params = (spine_start, spine_end, *f.params)
+    if limit is not None:
+        params = (*params, limit)
 
     with get_conn() as conn:
         with conn.cursor() as cur:

--- a/src/backend/services/station_stats/ride_counts.py
+++ b/src/backend/services/station_stats/ride_counts.py
@@ -1,5 +1,5 @@
 from src.backend.db import fetch_rows, get_conn
-from src.backend.models.ride import MemberCasual, RideableType
+from src.backend.models.params import MonthRange, StationFilters
 from src.backend.models.station_stats.ride_counts import GroupedStationRideCount, StationRideGroupBy, StationRideCounts
 from src.backend.services.sql.query_builder import (
     Filters,
@@ -7,16 +7,10 @@ from src.backend.services.sql.query_builder import (
     dims_join_condition,
     spine_cte_sql,
 )
-from src.backend.services.sql.spine import month_range_bounds
 
 def get_station_ride_counts_stats(
-    start_year: int,
-    start_month: int,
-    end_year: int,
-    end_month: int,
-    user_type: MemberCasual | None = None,
-    bike_type: RideableType | None = None,
-    station_id: str | None = None,
+    month_range: MonthRange,
+    filters: StationFilters,
     day_of_week: int | None = None,
     group_by: StationRideGroupBy = StationRideGroupBy.NONE,
     limit: int = 100,
@@ -24,7 +18,7 @@ def get_station_ride_counts_stats(
     """Fetch per-station ride counts, following the shared spine pattern: a calendar
     hours CTE provides hours_count per bucket, ride aggregates are computed per
     station and bucket, and the top stations are selected in SQL."""
-    spine_start, spine_end = month_range_bounds(start_year, start_month, end_year, end_month)
+    spine_start, spine_end = month_range.bounds()
 
     # Pick the smallest pre-aggregated table that satisfies the query shape, the
     # time dimensions to bucket by, and whether the table has a day_of_week column.
@@ -47,14 +41,14 @@ def get_station_ride_counts_stats(
 
     # Fact-table filters, shared by the top-station selection and the bucketed select.
     f = Filters()
-    f.add("(sah.year, sah.month) >= (%s, %s)", start_year, start_month)
-    f.add("(sah.year, sah.month) <= (%s, %s)", end_year, end_month)
-    if station_id is not None:
-        f.add("sah.station_id = %s", station_id)
-    if user_type is not None:
-        f.add("sah.user_type = %s", user_type.value)
-    if bike_type is not None:
-        f.add("sah.bike_type = %s", bike_type.value)
+    f.add("(sah.year, sah.month) >= (%s, %s)", month_range.start_year, month_range.start_month)
+    f.add("(sah.year, sah.month) <= (%s, %s)", month_range.end_year, month_range.end_month)
+    if filters.station_id is not None:
+        f.add("sah.station_id = %s", filters.station_id)
+    if filters.user_type is not None:
+        f.add("sah.user_type = %s", filters.user_type.value)
+    if filters.bike_type is not None:
+        f.add("sah.bike_type = %s", filters.bike_type.value)
     if day_of_week is not None and has_dow_col:
         f.add("sah.day_of_week = %s", day_of_week)
 

--- a/src/backend/tests/test_stats.py
+++ b/src/backend/tests/test_stats.py
@@ -119,7 +119,7 @@ def test_get_stats_grouped_by_weather():
 
 
 def test_get_stats_by_weather_temperature_bins():
-    """Test that variable=temperature buckets spine hours into 2°C bins."""
+    """Test that variable=temperature buckets spine hours into whole-degree bins."""
     response = requests.get(
         f"{BASE_URL}/stats/stats_by_weather",
         params={**DATE_PARAMS, "variable": "temperature"},
@@ -129,16 +129,17 @@ def test_get_stats_by_weather_temperature_bins():
     payload = response.json()
 
     bins = {row["weather_bin"]: row for row in payload}
-    # Seed temps -1.8..5.2 °C: 5 hours below 0°, 5 in [0,2), 8 in [2,4), 6 in [4,6)
-    assert sorted(bins) == [-2.0, 0.0, 2.0, 4.0]
-    assert [bins[b]["hours_count"] for b in sorted(bins)] == [5, 5, 8, 6]
+    # Seed temps -1.8..5.2 °C floored to whole degrees:
+    # -2:4h, -1:1h, 1:5h, 2:4h, 3:4h, 4:4h, 5:2h (no hour lands in [0,1))
+    assert sorted(bins) == [-2.0, -1.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert [bins[b]["hours_count"] for b in sorted(bins)] == [4, 1, 5, 4, 4, 4, 2]
     assert all(row["weather_code"] is None for row in payload)
-    # Rides at hour 5 (1.3 °C → bin 0) and hour 15 (5.2 °C → bin 4)
-    assert bins[0.0]["total_rides"] == 1
-    assert bins[4.0]["total_rides"] == 1
-    # Bin 0: per-hour counts [1, 0, 0, 0, 0] → sample std sqrt(0.2)
-    assert bins[0.0]["hours_with_rides"] == 1
-    assert abs(bins[0.0]["rides_per_hour_std"] - 0.2 ** 0.5) < 1e-9
+    # Rides at hour 5 (1.3 °C → bin 1) and hour 15 (5.2 °C → bin 5)
+    assert bins[1.0]["total_rides"] == 1
+    assert bins[5.0]["total_rides"] == 1
+    # Bin 1: per-hour counts [1, 0, 0, 0, 0] → sample std sqrt(0.2)
+    assert bins[1.0]["hours_with_rides"] == 1
+    assert abs(bins[1.0]["rides_per_hour_std"] - 0.2 ** 0.5) < 1e-9
 
 
 def test_get_stats_by_weather_precipitation_bins():
@@ -248,6 +249,30 @@ def test_get_trips_between_stations_with_invalid_station_id():
     assert response.status_code == 200
     payload = response.json()
     assert payload == []
+
+def test_get_trips_between_stations_all_partners_without_limit():
+    """Test that /stats/station_flow_counts with station_id and no limit returns every partner pair."""
+    response = requests.get(
+        f"{BASE_URL}/stats/station_flow_counts",
+        params={**YM_PARAMS, "station_id": "6602.05"},
+        timeout=DEFAULT_TIMEOUT,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    pair = payload[0]
+    assert {pair["station_a_id"], pair["station_b_id"]} == {"6602.05", "6839.04"}
+
+def test_get_trips_between_stations_respects_explicit_limit():
+    """Test that /stats/station_flow_counts truncates to an explicit limit."""
+    response = requests.get(
+        f"{BASE_URL}/stats/station_flow_counts",
+        params={**YM_PARAMS, "limit": 1},
+        timeout=DEFAULT_TIMEOUT,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
 
 def test_get_station_counts():
     """Test that /stats/station_usage_counts returns expected station counts."""

--- a/src/ingestion/config.py
+++ b/src/ingestion/config.py
@@ -55,6 +55,7 @@ class IngestionSettings(BaseSettings):
     parquet_compression: str
     street_circuity_factor: float
     earth_radius_km: float
+    upper_outlier_z_score: float
 
     # Weather retrieval settings
     nyc_coords: tuple[float, float]

--- a/src/ingestion/config.yaml
+++ b/src/ingestion/config.yaml
@@ -36,6 +36,7 @@ yearly_cutoff: 2023         # Files with only a year <= this are assumed to cove
 parquet_compression: zstd
 street_circuity_factor: 1.3
 earth_radius_km: 6371
+upper_outlier_z_score: 1.645  # One-sided 95% z-score cutoff for duration and distance outliers
 
 # Weather retrieval settings
 nyc_coords: [40.7823234, -73.9654161]

--- a/src/ingestion/sources/rides.py
+++ b/src/ingestion/sources/rides.py
@@ -230,9 +230,28 @@ def _iter_month_frames(zip_path: Path) -> Iterator[pl.DataFrame]:
                 return
             yield pl.concat(frames, how="diagonal_relaxed")
 
+def _haversine_km_expr() -> pl.Expr:
+    """Great-circle distance (km) between the start and end coordinates, circuity-scaled."""
+    lat1, lon1 = pl.col("start_lat").radians(), pl.col("start_lng").radians()
+    lat2, lon2 = pl.col("end_lat").radians(), pl.col("end_lng").radians()
+    a = ((lat2 - lat1) / 2).sin() ** 2 + lat1.cos() * lat2.cos() * ((lon2 - lon1) / 2).sin() ** 2
+    return settings.earth_radius_km * 2 * a.sqrt().arcsin() * settings.street_circuity_factor
+
+
+def _upper_outlier_cutoff(df: pl.DataFrame, column: str) -> float | None:
+    """Return the upper 95% z-score cutoff, or None when variation is unavailable."""
+    stats = df.select(
+        pl.col(column).mean().alias("mean"),
+        pl.col(column).std(ddof=1).alias("std"),
+    ).row(0, named=True)
+    mean, std = stats["mean"], stats["std"]
+    if mean is None or std is None or std <= 0:
+        return None
+    return float(mean + settings.upper_outlier_z_score * std)
+
 def _clean_rides_data(df: pl.DataFrame) -> pl.DataFrame:
-    """Drop rows missing required fields, parse timestamps, drop bad intervals."""
-    return (
+    """Clean rides and exclude independent upper-tail duration/distance outliers."""
+    valid = (
         df.drop_nulls(subset=_REQUIRED_RIDE_COLS)
         .with_columns(
             pl.col("started_at").str.to_datetime(format="%Y-%m-%d %H:%M:%S%.f", strict=True),
@@ -240,7 +259,26 @@ def _clean_rides_data(df: pl.DataFrame) -> pl.DataFrame:
         )
         .drop_nulls(subset=["started_at", "ended_at"])
         .filter(pl.col("ended_at") >= pl.col("started_at"))
+        # Drop round trips (same start and end station): their straight-line distance is 0.
+        .filter(pl.col("start_station_id") != pl.col("end_station_id"))
+        .with_columns(
+            (pl.col("ended_at") - pl.col("started_at"))
+            .dt.total_seconds()
+            .alias("_trip_duration_seconds"),
+            _haversine_km_expr().alias("_distance_km"),
+        )
     )
+
+    duration_cutoff = _upper_outlier_cutoff(valid, "_trip_duration_seconds")
+    distance_cutoff = _upper_outlier_cutoff(valid, "_distance_km")
+    filters = []
+    if duration_cutoff is not None:
+        filters.append(pl.col("_trip_duration_seconds") <= duration_cutoff)
+    if distance_cutoff is not None:
+        filters.append(pl.col("_distance_km") <= distance_cutoff)
+    if filters:
+        valid = valid.filter(pl.all_horizontal(filters))
+    return valid.drop(["_trip_duration_seconds", "_distance_km"])
 
 def _add_partition_columns(df: pl.DataFrame) -> pl.DataFrame:
     """Add date/year/month/hour/day_of_week/duration columns derived from ended_at.

--- a/src/ingestion/sources/weather.py
+++ b/src/ingestion/sources/weather.py
@@ -39,8 +39,14 @@ def _get_date_range(min_date: str, max_date: str) -> tuple[date, date]:
     end = min(_yyyymm_to_last_of_month(range_end_yyyymm), date.today())
     return start, end
 
-def _create_weather_dataframe(weather_json: dict) -> pl.DataFrame:
-    """Convert the Open-Meteo hourly payload into a parquet-ready DataFrame."""
+def _create_weather_dataframe(weather_json: dict, start: date, end: date) -> pl.DataFrame:
+    """Convert the Open-Meteo hourly payload into a parquet-ready DataFrame.
+
+    Timestamps arrive in UTC and are localised here rather than by the API: the
+    archive applies a single fixed offset to a whole request (whichever one the
+    location is on today), so asking it for local time mislabels by an hour every
+    date sitting on the other side of a DST boundary.
+    """
     hourly = weather_json.get("hourly", {})
     if not hourly or not hourly.get("time"):
         raise ValueError("Weather API response did not include hourly data")
@@ -48,8 +54,15 @@ def _create_weather_dataframe(weather_json: dict) -> pl.DataFrame:
     return (
         pl.DataFrame(hourly)
         .with_columns(
-            pl.col("time").str.strptime(pl.Datetime, format="%Y-%m-%dT%H:%M").alias("datetime"),
+            pl.col("time")
+            .str.strptime(pl.Datetime, format="%Y-%m-%dT%H:%M")
+            .dt.replace_time_zone("UTC")
+            .dt.convert_time_zone(settings.weather_timezone)
+            .dt.replace_time_zone(None)
+            .alias("datetime"),
         )
+        # The UTC window is padded by a day on each side, so trim back to the days asked for.
+        .filter(pl.col("datetime").dt.date().is_between(start, end))
         .with_columns(
             # Year column drives the parquet partitioning
             pl.col("datetime").dt.year().alias("year"),
@@ -66,23 +79,25 @@ def download_weather_data(min_date: str, max_date: str, force_download: bool = F
     start_date, end_date = _get_date_range(min_date, max_date)
 
     log.info(f"[DOWNLOAD] Downloading weather {start_date.isoformat()} -> {end_date.isoformat()}...")
+    # Pad the requested window by a day on each side so that shifting UTC back to
+    # local time still covers both endpoints (the archive stops at today).
     response = requests.get(
         settings.weather_api_url,
         params={
             "latitude":        settings.nyc_coords[0],
             "longitude":       settings.nyc_coords[1],
-            "start_date":      start_date.isoformat(),
-            "end_date":        end_date.isoformat(),
+            "start_date":      (start_date - timedelta(days=1)).isoformat(),
+            "end_date":        min(end_date + timedelta(days=1), date.today()).isoformat(),
             # Hourly granularity is the smallest resolution available across the full historical range
             "hourly":          "temperature_2m,precipitation,weather_code,wind_speed_10m",
-            "timezone":        settings.weather_timezone,
+            "timezone":        "UTC",
             "wind_speed_unit": "kmh",
         },
         timeout=(5, 120),
     )
     response.raise_for_status()
 
-    weather_data = _create_weather_dataframe(response.json())
+    weather_data = _create_weather_dataframe(response.json(), start_date, end_date)
     weather_data.write_parquet(
         settings.weather_data_dir,
         row_group_size=100_000,

--- a/src/ingestion/tests/test_rides.py
+++ b/src/ingestion/tests/test_rides.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+
+import polars as pl
+
+from src.ingestion.sources.rides import _clean_rides_data
+
+
+def _ride(ride_id: str, duration_minutes: int, end_lng: float) -> dict:
+    started_at = datetime(2025, 2, 1, 8, 0)
+    return {
+        "ride_id": ride_id,
+        "rideable_type": "classic_bike",
+        "started_at": started_at.strftime("%Y-%m-%d %H:%M:%S"),
+        "ended_at": (started_at + timedelta(minutes=duration_minutes)).strftime("%Y-%m-%d %H:%M:%S"),
+        "start_station_name": "Start",
+        "start_station_id": "start",
+        "end_station_name": "End",
+        "end_station_id": f"end-{ride_id}",
+        "start_lat": 40.75,
+        "start_lng": -73.99,
+        "end_lat": 40.75,
+        "end_lng": end_lng,
+        "member_casual": "member",
+    }
+
+
+def test_clean_rides_removes_independent_upper_tail_outliers():
+    normal = [_ride(str(index), 10 + index, -73.989 + index * 0.001) for index in range(30)]
+    duration_outlier = _ride("duration-outlier", 24 * 60, -73.98)
+    distance_outlier = _ride("distance-outlier", 20, 0.0)
+
+    cleaned = _clean_rides_data(pl.DataFrame([*normal, duration_outlier, distance_outlier]))
+
+    assert cleaned.height == len(normal)
+    assert set(cleaned["ride_id"]) == {str(index) for index in range(30)}
+
+
+def test_clean_rides_keeps_values_when_a_metric_has_zero_variance():
+    rides = [_ride(str(index), 15, -73.98) for index in range(3)]
+
+    cleaned = _clean_rides_data(pl.DataFrame(rides))
+
+    assert cleaned.height == 3


### PR DESCRIPTION
Consolidates repeated stats query parameters into shared models and applies the cleaning rules the notebook analysis identified.

### Changes

- **Query parameter models:** added `models/params.py` with reusable `DateRange`, `MonthRange`, `RideFilters` and `StationFilters` dependency models. The stats endpoints now declare them via `Depends()` instead of repeating the same parameter lists, and range validation moves out of the standalone `sql/spine` helpers into the models. The query-string contract is unchanged.
- **Weather bins:** temperature is now bucketed by whole degrees instead of 2-degree steps.
- **Ride ingestion:** round trips (same start and end station, so zero straight-line distance) and upper-tail duration/distance outliers are dropped, using a configurable one-sided 95% z-score cutoff (`upper_outlier_z_score`).
- **Weather ingestion:** fetch in UTC with a one-day pad on each side and localise timestamps ourselves. The archive API applies one fixed offset per request, which mislabelled every date on the other side of a DST boundary by an hour.
- **Bike facility classes:** corrected the `FacilityClass` labels to the NYC OpenData definitions (Protected / Conventional / Shared Lane or Signed Route / Link).
- **Tests:** added ingestion unit tests for the ride cleaning rules and extended the stats integration tests.
