### PR TITLE
Fix the docs workflow PDF publish step

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # main is protected, so pushing the refreshed PDFs needs a token allowed to
+        # bypass the pull request requirement. Pull request runs only compile, so
+        # they fall back to the default token.
+        with:
+          token: ${{ secrets.DOCS_PDF_TOKEN || github.token }}
 
       - name: Compile proposal document
         uses: xu-cheng/latex-action@v3
@@ -49,13 +54,21 @@ jobs:
           mv docs/report/report.pdf docs/report.pdf
           mv docs/technical-report/technical-report.pdf docs/technical-report.pdf
       
+      # Only push runs update the committed PDFs: a pull request run is checked out
+      # in detached HEAD on the merge commit, so it has no branch to push and its
+      # PDFs describe a merge that may never happen.
       - name: Update PDF in repository
+        if: github.event_name == 'push'
         run: |
           git config user.name "GitHub Actions"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/proposal.pdf
           git add docs/report.pdf
           git add docs/technical-report.pdf
-          git commit -m "Update compiled PDF documents" || echo "No changes to commit"
-          git push origin main
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update compiled PDF documents"
+          git push origin HEAD:main
 


### PR DESCRIPTION
The `Update PDF in repository` step has been failing on every run, for two different reasons.

- **On pull requests:** `actions/checkout` leaves the workspace in detached HEAD on the merge commit, so `git push origin main` had no local `main` to push and failed with `src refspec main does not match any`.
- **On pushes to `main`:** the push is now rejected outright — `GH006: Protected branch update failed ... Changes must be made through a pull request`.

### Changes

- Restrict the commit and push to `push` events. Pull requests now just compile the three documents, which makes `Docs Build` a genuine build check instead of a guaranteed red cross.
- Check out with a `DOCS_PDF_TOKEN` secret so the push can bypass branch protection, falling back to the default `github.token` when the secret is absent (so pull request runs keep working unchanged).
- Push `HEAD:main` explicitly, and skip the commit entirely when the PDFs are unchanged rather than committing and pushing a no-op.

### Setup still required

The push will keep failing until the token exists and is allowed through branch protection:

1. Create a fine-grained personal access token scoped to this repository with **Contents: Read and write**.
2. Add it as the repository secret **`DOCS_PDF_TOKEN`** (Settings → Secrets and variables → Actions).
3. Add that token's owner to the bypass list under Settings → Rules/Branches → `main` → *Allow specified actors to bypass required pull requests*.

Without step 3 the token is still subject to the protection rule and the push is rejected the same way.
